### PR TITLE
fix(sandpack-core): loaderContext.emitModule() may replace tModule directly

### DIFF
--- a/packages/sandpack-core/src/manager.ts
+++ b/packages/sandpack-core/src/manager.ts
@@ -508,6 +508,14 @@ export default class Manager implements IEvaluator {
   }
 
   addTranspiledModule(module: Module, query: string = ''): TranspiledModule {
+    if (
+      this.transpiledModules[module.path] &&
+      this.transpiledModules[module.path].tModules[query] &&
+      this.transpiledModules[module.path].module.code === module.code
+    ) {
+      // fix: loaderContext.emitModule() may replace tModule directly
+      return this.transpiledModules[module.path].tModules[query];
+    }
     if (!this.transpiledModules[module.path]) {
       this.addModule(module);
     }


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## What kind of change does this PR introduce?
Bug fix
<!-- Is it a Bug fix, feature, docs update, ... -->

## What is the current behavior?
vue2 project HRM fails
<!-- You can also link to an open issue here -->

## What is the new behavior?
vue2 project HRM works

<!-- if this is a feature change -->

## What steps did you take to test this? This is required before we can merge, make sure to test the flow you've updated.

1. create a vue2 project
2. modify  App.vue file
3. see if HRM work correctly and without errors

## Checklist

<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ x] Documentation
- [ x] Testing <!-- We can only merge the PR if this is checked -->
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
## Cause Analysis
when a vue componet is created, [vue-hot-reload-api](https://github.com/vuejs/vue-hot-reload-api/blob/master/src/index.js#L3) will call `createRecord()` and keep its records in module scope. when HRM is triggered, `vue-hot-reload-api` will call `rerender` which reference saved records. so if we replace its tModules, we lost the records, thus raise an error.